### PR TITLE
Update api.js

### DIFF
--- a/plugins/api.js
+++ b/plugins/api.js
@@ -297,7 +297,7 @@ function downvote(options) {
 }
 
 function setSecondSecret(options) {
-  var trs = aschJS.signature.createSignature(options.secret, options.secondSecret);
+  var trs = aschJS.basic.setSecondSecret(options.secret, options.secondSecret);
   getApi().broadcastTransaction(trs, function (err, result) {
     console.log(err || result.transactionId)
   });


### PR DESCRIPTION
Set the second secret. Notice only works after the latest version of asch-js is merged into the master. The latest version of asch-js is required, see also https://github.com/AschPlatform/asch-js/blob/develop/lib/transactions/basic.js. It seems that https://github.com/AschPlatform/asch-js/blob/master/lib/transactions/signature.js can be dropped too after the merge.